### PR TITLE
use DeriveAnyClass to derive Enumerable where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ data IntProp
   | IsMaxBound
   | IsMinBound
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable IntProp where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass Enumerable
 ```
 Here is a model for integers. We have partitioned the space of integers into a smaller easier to manage space. This will be a sufficient description to test the example function defined later. It is sufficient since the function should return true/false according to a formula defined in terms of the above propositions. By modelling integers like this we also make sure that we test some specific extremal values in the space.
 

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -10,6 +10,7 @@ common lang
     BinaryLiterals
     ConstraintKinds
     DataKinds
+    DeriveAnyClass
     DeriveFunctor
     DeriveGeneric
     DeriveTraversable

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -10,6 +10,7 @@ common lang
     BinaryLiterals
     ConstraintKinds
     DataKinds
+    DefaultSignatures
     DeriveAnyClass
     DeriveFunctor
     DeriveGeneric

--- a/examples/Spec/Int.hs
+++ b/examples/Spec/Int.hs
@@ -1,4 +1,4 @@
-module Spec.Int (HasLogicalModel (..), IntProp (..), intGenTests, intPureTests ) where
+module Spec.Int (HasLogicalModel (..), IntProp (..), intGenTests, intPureTests) where
 
 import Apropos
 import Test.Tasty (TestTree, testGroup)
@@ -13,9 +13,7 @@ data IntProp
   | IsMaxBound
   | IsMinBound
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable IntProp where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel IntProp where
   logic =
@@ -70,4 +68,3 @@ intPureTests =
     fromGroup
       <$> [ runPureTestsWhere (Apropos :: Int :+ IntProp) "AcceptsSmallNegativeInts" Yes
           ]
-

--- a/examples/Spec/IntPermutationGen.hs
+++ b/examples/Spec/IntPermutationGen.hs
@@ -18,9 +18,7 @@ data IntProp
   | IsMaxBound
   | IsMinBound
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable IntProp where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel IntProp where
   logic =

--- a/examples/Spec/TicTacToe/Location.hs
+++ b/examples/Spec/TicTacToe/Location.hs
@@ -16,9 +16,7 @@ data LocationProperty
   = LocationIsWithinBounds
   | LocationIsOutOfBounds
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable LocationProperty where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel LocationProperty where
   logic = ExactlyOne $ Var <$> [LocationIsWithinBounds, LocationIsOutOfBounds]

--- a/examples/Spec/TicTacToe/LocationSequence.hs
+++ b/examples/Spec/TicTacToe/LocationSequence.hs
@@ -22,9 +22,7 @@ data LocationSequenceProperty
   | LocationSequenceIsSingleton
   | LocationSequenceIsLongerThanGame
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable LocationSequenceProperty where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel LocationSequenceProperty where
   logic =

--- a/examples/Spec/TicTacToe/Player.hs
+++ b/examples/Spec/TicTacToe/Player.hs
@@ -17,9 +17,7 @@ data PlayerProperty
   | PlayerIsO
   | PlayerIsInvalid
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable PlayerProperty where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel PlayerProperty where
   logic = ExactlyOne $ Var <$> [PlayerIsInvalid, PlayerIsX, PlayerIsO]

--- a/examples/Spec/TicTacToe/PlayerSequence.hs
+++ b/examples/Spec/TicTacToe/PlayerSequence.hs
@@ -19,9 +19,7 @@ data PlayerSequenceProperty
   | PlayerSequenceSingleton
   | PlayerSequenceIsLongerThanGame
   deriving stock (Eq, Ord, Enum, Show, Bounded)
-
-instance Enumerable PlayerSequenceProperty where
-  enumerated = [minBound .. maxBound]
+  deriving anyclass (Enumerable)
 
 instance LogicalModel PlayerSequenceProperty where
   logic =

--- a/src/Apropos/LogicalModel/Enumerable.hs
+++ b/src/Apropos/LogicalModel/Enumerable.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE DefaultSignatures #-}
+
 module Apropos.LogicalModel.Enumerable (
   Enumerable (..),
 ) where
 
 class (Eq p, Ord p) => Enumerable p where
   enumerated :: [p]
+  default enumerated :: (Enum p, Bounded p) => [p]
+  enumerated = [minBound .. maxBound]

--- a/src/Apropos/LogicalModel/Enumerable.hs
+++ b/src/Apropos/LogicalModel/Enumerable.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DefaultSignatures #-}
-
 module Apropos.LogicalModel.Enumerable (
   Enumerable (..),
 ) where


### PR DESCRIPTION
All the (non TH) Enumerable instances in the examples use the same definition so this seemed like a better way to do it.