### PR TITLE
jhodgdev/remove-base-constraint

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-eval "$(lorri direnv)"

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ Thumbs.db
 
 # Local configuration files
 cabal.project.local*
+
+# direnv 
+.envrc 
+.direnv

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -39,7 +39,7 @@ common lang
     TypeSynonymInstances
     UndecidableInstances
 
-  build-depends:      base ^>=4.14
+  build-depends:      base >=4.14
                     , containers
                     , hedgehog
                     , free


### PR DESCRIPTION
I have changed the `base ^>=4.14` constraint in the Cabal file to `base >=4.14`. Would fix #6. If we would like to concretely constrain the base version, I _believe_ that 4.15 or 4.16 would be compatible with `plutus-scaffold`.