### PR TITLE
Ported CI improvements from apropos-tx

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -3,4 +3,4 @@
 # Extensions necessary to tell fourmolu about 
 EXTENSIONS="-o -XTypeApplications -o -XTemplateHaskell -o -XImportQualifiedPost -o -XPatternSynonyms -o -fplugin=RecordDotPreprocessor -o -XBangPatterns"
 SOURCES=$(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
-~/.local/bin/fourmolu --mode check --check-idempotence $EXTENSIONS $SOURCES
+fourmolu --mode check --check-idempotence $EXTENSIONS $SOURCES

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -4,8 +4,11 @@ on:
       - '**.hs'
       - '**.nix'
       - 'nix/sources.json'
-      - 'apropos.cabal'
+      - 'apropos-tx.cabal'
+      - '.github/*'
+      - '.github/workflows/*'
     branches:
+      - main
       - master
       - staging
   pull_request:
@@ -13,66 +16,63 @@ on:
       - '**.hs'
       - '**.nix'
       - 'nix/sources.json'
-      - 'apropos.cabal'
+      - 'apropos-tx.cabal'
 jobs:
-  check-formatting:
+  fourmolu-check: 
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2.1.4
-        name: Cache Stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-formatting
-          restore-keys: ${{ runner.os }}-stack-
-
-      - run: stack install fourmolu
-        name: Setup
-
-      - run: ./.github/format.sh
-        name: "Run fourmolu"
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2.1.4
-        name: Cache Stack
-        with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-lint
-          restore-keys: ${{ runner.os }}-stack-
-
-      - run: stack install hlint
-        name: Setup
-
-      - run: ~/.local/bin/hlint $(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
-        name: Lint
-  build:
-    runs-on: ubuntu-latest
-    steps:
+    steps: 
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v13
         name: Set up nix and IOHK cache
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-21.11
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
+            experimental-features = nix-command flakes
       - uses: cachix/cachix-action@v10
         with:
           name: mlabs
           authToken: ${{ secrets.CACHIX_KEY }}
-      - name: Cache cabal folder
-        id: cabal
-        uses: actions/cache@v2.1.4
+      - run: nix-env -iA haskellPackages.fourmolu -f '<nixpkgs>'
+        name: Install fourmolu
+      - run: ./.github/format.sh
+        name: Format
+  hlint-check: 
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v13
+        name: Set up nix and IOHK cache
         with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            dist-newstyle
-          key: ${{ runner.os }}-cabal
+          nix_path: nixpkgs=channel:nixos-21.11
+          extra_nix_config: |
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
+            experimental-features = nix-command flakes
+      - uses: cachix/cachix-action@v10
+        with:
+          name: mlabs
+          authToken: ${{ secrets.CACHIX_KEY }}
+      - run: nix-env -iA hlint -f '<nixpkgs>'
+        name: Install hlint
+      - run: hlint $(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
+        name: Lint
+  cabal-check: 
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v13
+        name: Set up nix and IOHK cache
+        with:
+          nix_path: nixpkgs=channel:nixos-21.11
+          extra_nix_config: |
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://hydra.iohk.io https://iohk.cachix.org https://cache.nixos.org/
+            experimental-features = nix-command flakes
+      - uses: cachix/cachix-action@v10
+        with:
+          name: mlabs
+          authToken: ${{ secrets.CACHIX_KEY }}
       - name: Build the full ci derivation
-        run: nix build .#check.x86_64-linux --extra-experimental-features nix-command --extra-experimental-features flakes
+        run: nix build .#check.x86_64-linux

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -4,7 +4,7 @@ on:
       - '**.hs'
       - '**.nix'
       - 'nix/sources.json'
-      - 'apropos-tx.cabal'
+      - 'apropos.cabal'
       - '.github/*'
       - '.github/workflows/*'
     branches:
@@ -16,7 +16,7 @@ on:
       - '**.hs'
       - '**.nix'
       - 'nix/sources.json'
-      - 'apropos-tx.cabal'
+      - 'apropos.cabal'
 jobs:
   fourmolu-check: 
     runs-on: ubuntu-latest

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -3,7 +3,7 @@ name:               apropos
 version:            1.0
 extra-source-files: CHANGELOG.md
 
--- Trigger CI
+-- Trigger CI for real this time
 common lang
   default-language:   Haskell2010
   default-extensions:

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -3,6 +3,7 @@ name:               apropos
 version:            1.0
 extra-source-files: CHANGELOG.md
 
+-- Trigger CI
 common lang
   default-language:   Haskell2010
   default-extensions:

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -3,7 +3,6 @@ name:               apropos
 version:            1.0
 extra-source-files: CHANGELOG.md
 
--- Trigger CI for real this time
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -12,7 +11,7 @@ common lang
     ConstraintKinds
     DataKinds
     DefaultSignatures
-   DeriveAnyClass
+    DeriveAnyClass
     DeriveFunctor
     DeriveGeneric
     DeriveTraversable
@@ -40,69 +39,73 @@ common lang
     TypeSynonymInstances
     UndecidableInstances
 
-  build-depends:      base >=4.14
-                    , containers
-                    , hedgehog
-                    , free
-                    , lens
-                    , minisat-solver
-                    , mtl
-                    , pretty
-                    , pretty-show
-                    , safe
-                    , template-haskell
-                    , text
-                    , transformers
+  build-depends:
+    , base              >=4.14
+    , containers
+    , free
+    , hedgehog
+    , lens
+    , minisat-solver
+    , mtl
+    , pretty
+    , pretty-show
+    , safe
+    , template-haskell
+    , text
+    , transformers
+
   ghc-options:
     -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints
     -Wmissing-export-lists -Werror -Wincomplete-record-updates
-    -Wmissing-deriving-strategies
-    -ddump-splices
+    -Wmissing-deriving-strategies -ddump-splices
 
 library
   import:          lang
-  exposed-modules: Apropos
-                 , Apropos.Gen
-                 , Apropos.Gen.Enumerate
-                 , Apropos.Gen.Range
-                 , Apropos.HasAbstractions
-                 , Apropos.HasLogicalModel
-                 , Apropos.HasParameterisedGenerator
-                 , Apropos.HasPermutationGenerator
-                 , Apropos.HasPermutationGenerator.Abstraction
-                 , Apropos.HasPermutationGenerator.Contract
-                 , Apropos.HasPermutationGenerator.Morphism
-                 , Apropos.LogicalModel
-                 , Apropos.LogicalModel.Enumerable
-                 , Apropos.LogicalModel.Formula
-                 , Apropos.Pure
-                 , Apropos.Type
+  exposed-modules:
+    Apropos
+    Apropos.Gen
+    Apropos.Gen.Enumerate
+    Apropos.Gen.Range
+    Apropos.HasAbstractions
+    Apropos.HasLogicalModel
+    Apropos.HasParameterisedGenerator
+    Apropos.HasPermutationGenerator
+    Apropos.HasPermutationGenerator.Abstraction
+    Apropos.HasPermutationGenerator.Contract
+    Apropos.HasPermutationGenerator.Morphism
+    Apropos.LogicalModel
+    Apropos.LogicalModel.Enumerable
+    Apropos.LogicalModel.Formula
+    Apropos.Pure
+    Apropos.Type
+
   hs-source-dirs:  src
 
 test-suite examples
-  import: lang
-  type: exitcode-stdio-1.0
-  main-is: Main.hs
+  import:         lang
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
   hs-source-dirs: examples
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-N
   other-modules:
     Spec.Int
-    Spec.IntPermutationGen
-    Spec.IntPair
     Spec.IntEither
-    Spec.TicTacToe.Player
-    Spec.TicTacToe.PlayerSequence
+    Spec.IntPair
+    Spec.IntPermutationGen
     Spec.TicTacToe.Location
     Spec.TicTacToe.LocationSequence
-    Spec.TicTacToe.PlayerLocationSequencePair
     Spec.TicTacToe.Move
     Spec.TicTacToe.MoveSequence
+    Spec.TicTacToe.Player
+    Spec.TicTacToe.PlayerLocationSequencePair
+    Spec.TicTacToe.PlayerSequence
+
   build-depends:
-    base,
-    apropos,
-    tasty,
-    tasty-hedgehog,
-    hedgehog,
-    text,
-    containers,
-    mtl,
+    , apropos
+    , base
+    , containers
+    , hedgehog
+    , mtl
+    , tasty
+    , tasty-hedgehog
+    , text

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -154,7 +154,7 @@ class (HasLogicalModel p m, Show m) => HasPermutationGenerator p m where
     (Set p, Set p)
   findNoPath _ m g =
     minimumBy
-      (compare `on` (uncurry score))
+      (compare `on` uncurry score)
       [ (lut m a, lut m b)
       | a <- Map.keys m
       , b <- Map.keys m


### PR DESCRIPTION
I have altered the CI workflow so that hlint and fourmolu now install via Nix rather than Stack. This has fixed the CI issues we were getting wherein mismatched tool versions were in some cases preventing make format and make lint from detecting issues that the CI would find and complain about. CI times are now as quick as the Stack solution (when the tools were cached successfully) and significantly quicker than the Stack solution when the tools were not cached.