### PR TITLE
evaluate contracts to edges using the SAT solver

### DIFF
--- a/apropos.cabal
+++ b/apropos.cabal
@@ -79,6 +79,7 @@ library
     Apropos.LogicalModel.Formula
     Apropos.Pure
     Apropos.Type
+    Apropos.SetFunctionFormula
 
   hs-source-dirs:  src
 

--- a/apropos.cabal
+++ b/apropos.cabal
@@ -78,8 +78,8 @@ library
     Apropos.LogicalModel.Enumerable
     Apropos.LogicalModel.Formula
     Apropos.Pure
-    Apropos.Type
     Apropos.SetFunctionFormula
+    Apropos.Type
 
   hs-source-dirs:  src
 

--- a/src/Apropos/SetFunctionFormula.hs
+++ b/src/Apropos/SetFunctionFormula.hs
@@ -1,0 +1,80 @@
+module Apropos.SetFunctionFormula (
+    findEdges
+  , adds
+  , removes
+  , SetFunctionLanguage
+  ) where
+import Apropos.LogicalModel.Formula
+import Apropos.LogicalModel.Enumerable
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Control.Monad (join)
+import Data.Maybe (fromMaybe)
+import Control.Monad.Free
+import Control.Monad.State (State, execState, get, put)
+
+findEdges :: Enumerable a => SetFunctionLanguage a () -> Set (Set a, Set a)
+findEdges expr = Set.fromList changes
+  where sols = solveAll $ setFunctionToFormula expr
+        tras = solutionToSetTranslation <$> sols
+        changes = filter (uncurry (/=)) tras
+
+adds :: a -> SetFunctionLanguage a ()
+adds a = liftF (Adds a ())
+
+removes :: a -> SetFunctionLanguage a ()
+removes a = liftF (Removes a ())
+
+data FreeSetFunctionLanguage a next =
+      Adds a next
+    | Removes a next
+
+instance Functor (FreeSetFunctionLanguage a) where
+  fmap f (Adds a next) = Adds a (f next)
+  fmap f (Removes a next) = Removes a (f next)
+
+type SetFunctionLanguage a = Free (FreeSetFunctionLanguage a)
+
+data S a = I a | O a deriving stock (Eq, Ord)
+
+setFunctionToFormula :: Enumerable a => SetFunctionLanguage a () -> Formula (S a)
+setFunctionToFormula = mapReprToFormula . setFunctionToMapRepr
+
+solutionToSetTranslation :: Enumerable a => Map (S a) Bool -> (Set a, Set a)
+solutionToSetTranslation sol = (i,o)
+  where i = Set.fromList [ x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (I x) sol) ]
+        o = Set.fromList [ x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (O x) sol) ]
+
+idSetFunctionMapRepr :: Enumerable a => Map (Formula a) (Formula a)
+idSetFunctionMapRepr =
+  Map.fromList $ join [ [ (Var x, Var x)
+                        , (Not (Var x), Not (Var x))
+                        ]
+                      | x <- enumerated
+                      ]
+
+setFunctionToMapRepr :: Enumerable a => SetFunctionLanguage a () -> Map (Formula a) (Formula a)
+setFunctionToMapRepr sfl = execState (evalSetFunctionOnMapRepr sfl) idSetFunctionMapRepr
+
+mapReprToFormula :: Map (Formula a) (Formula a) -> Formula (S a)
+mapReprToFormula mrep =
+  All [ (I <$> i) :->: (O <$> o)
+      | (i,o) <- Map.toList mrep
+      ]
+
+evalSetFunctionOnMapRepr :: Enumerable a => SetFunctionLanguage a () -> State (Map (Formula a) (Formula a)) ()
+evalSetFunctionOnMapRepr (Free (Adds a next)) = do
+  m <- get
+  let m' = Map.insert (Not (Var a)) (Var a) (Map.insert (Var a) (Var a) m)
+  put m'
+  evalSetFunctionOnMapRepr next
+evalSetFunctionOnMapRepr (Free (Removes a next)) = do
+  m <- get
+  let m' = Map.insert (Not (Var a)) (Not (Var a)) (Map.insert (Var a) (Not (Var a)) m)
+  put m'
+  evalSetFunctionOnMapRepr next
+evalSetFunctionOnMapRepr (Pure next) = pure next
+
+

--- a/src/Apropos/SetFunctionFormula.hs
+++ b/src/Apropos/SetFunctionFormula.hs
@@ -15,9 +15,9 @@ import Data.Maybe (fromMaybe)
 import Control.Monad.Free
 import Control.Monad.State (State, execState, get, put)
 
-findEdges :: Enumerable a => SetFunctionLanguage a () -> Set (Set a, Set a)
-findEdges expr = Set.fromList changes
-  where sols = solveAll $ setFunctionToFormula expr
+findEdges :: Enumerable a => Formula a -> SetFunctionLanguage a () -> Set (Set a, Set a)
+findEdges matches expr = Set.fromList changes
+  where sols = solveAll $ (I <$> matches) :&&: setFunctionToFormula expr
         tras = solutionToSetTranslation <$> sols
         changes = filter (uncurry (/=)) tras
 

--- a/src/Apropos/SetFunctionFormula.hs
+++ b/src/Apropos/SetFunctionFormula.hs
@@ -1,25 +1,27 @@
 module Apropos.SetFunctionFormula (
-    findEdges
-  , adds
-  , removes
-  , SetFunctionLanguage
-  ) where
-import Apropos.LogicalModel.Formula
+  findEdges,
+  adds,
+  removes,
+  SetFunctionLanguage,
+) where
+
 import Apropos.LogicalModel.Enumerable
-import Data.Set (Set)
-import Data.Set qualified as Set
-import Data.Map (Map)
-import Data.Map qualified as Map
+import Apropos.LogicalModel.Formula
 import Control.Monad (join)
-import Data.Maybe (fromMaybe)
 import Control.Monad.Free
 import Control.Monad.State (State, execState, get, put)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
 
 findEdges :: Enumerable a => Formula a -> SetFunctionLanguage a () -> Set (Set a, Set a)
 findEdges matches expr = Set.fromList changes
-  where sols = solveAll $ (I <$> matches) :&&: setFunctionToFormula expr
-        tras = solutionToSetTranslation <$> sols
-        changes = filter (uncurry (/=)) tras
+  where
+    sols = solveAll $ (I <$> matches) :&&: setFunctionToFormula expr
+    tras = solutionToSetTranslation <$> sols
+    changes = filter (uncurry (/=)) tras
 
 adds :: a -> SetFunctionLanguage a ()
 adds a = liftF (Adds a ())
@@ -27,9 +29,9 @@ adds a = liftF (Adds a ())
 removes :: a -> SetFunctionLanguage a ()
 removes a = liftF (Removes a ())
 
-data FreeSetFunctionLanguage a next =
-      Adds a next
-    | Removes a next
+data FreeSetFunctionLanguage a next
+  = Adds a next
+  | Removes a next
 
 instance Functor (FreeSetFunctionLanguage a) where
   fmap f (Adds a next) = Adds a (f next)
@@ -43,26 +45,30 @@ setFunctionToFormula :: Enumerable a => SetFunctionLanguage a () -> Formula (S a
 setFunctionToFormula = mapReprToFormula . setFunctionToMapRepr
 
 solutionToSetTranslation :: Enumerable a => Map (S a) Bool -> (Set a, Set a)
-solutionToSetTranslation sol = (i,o)
-  where i = Set.fromList [ x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (I x) sol) ]
-        o = Set.fromList [ x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (O x) sol) ]
+solutionToSetTranslation sol = (i, o)
+  where
+    i = Set.fromList [x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (I x) sol)]
+    o = Set.fromList [x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (O x) sol)]
 
 idSetFunctionMapRepr :: Enumerable a => Map (Formula a) (Formula a)
 idSetFunctionMapRepr =
-  Map.fromList $ join [ [ (Var x, Var x)
-                        , (Not (Var x), Not (Var x))
-                        ]
-                      | x <- enumerated
-                      ]
+  Map.fromList $
+    join
+      [ [ (Var x, Var x)
+        , (Not (Var x), Not (Var x))
+        ]
+      | x <- enumerated
+      ]
 
 setFunctionToMapRepr :: Enumerable a => SetFunctionLanguage a () -> Map (Formula a) (Formula a)
 setFunctionToMapRepr sfl = execState (evalSetFunctionOnMapRepr sfl) idSetFunctionMapRepr
 
 mapReprToFormula :: Map (Formula a) (Formula a) -> Formula (S a)
 mapReprToFormula mrep =
-  All [ (I <$> i) :->: (O <$> o)
-      | (i,o) <- Map.toList mrep
-      ]
+  All
+    [ (I <$> i) :->: (O <$> o)
+    | (i, o) <- Map.toList mrep
+    ]
 
 evalSetFunctionOnMapRepr :: Enumerable a => SetFunctionLanguage a () -> State (Map (Formula a) (Formula a)) ()
 evalSetFunctionOnMapRepr (Free (Adds a next)) = do
@@ -76,5 +82,3 @@ evalSetFunctionOnMapRepr (Free (Removes a next)) = do
   put m'
   evalSetFunctionOnMapRepr next
 evalSetFunctionOnMapRepr (Pure next) = pure next
-
-

--- a/src/Apropos/SetFunctionFormula.hs
+++ b/src/Apropos/SetFunctionFormula.hs
@@ -50,18 +50,19 @@ solutionToSetTranslation sol = (i, o)
     i = Set.fromList [x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (I x) sol)]
     o = Set.fromList [x | x <- enumerated, fromMaybe (error "undefined variable") (Map.lookup (O x) sol)]
 
-data SetFunctionRepr a =
-  ImplicationMap (Map (Formula a) (Formula a))
+data SetFunctionRepr a
+  = ImplicationMap (Map (Formula a) (Formula a))
 
 idSetFunctionRepr :: Enumerable a => SetFunctionRepr a
-idSetFunctionRepr = ImplicationMap $
-  Map.fromList $
-    join
-      [ [ (Var x, Var x)
-        , (Not (Var x), Not (Var x))
+idSetFunctionRepr =
+  ImplicationMap $
+    Map.fromList $
+      join
+        [ [ (Var x, Var x)
+          , (Not (Var x), Not (Var x))
+          ]
+        | x <- enumerated
         ]
-      | x <- enumerated
-      ]
 
 setFunctionToRepr :: Enumerable a => SetFunctionLanguage a () -> SetFunctionRepr a
 setFunctionToRepr sfl = execState (evalSetFunctionOnRepr sfl) idSetFunctionRepr


### PR DESCRIPTION
If we can write contracts and translate them to SAT then
we can use the SAT solver to speed up graph construction
by using it to enumerate the edges of the graph defined by
the morphims.