### PR TITLE
Pull out methods from `HasPureRunner`

### DIFF
--- a/src/Apropos.hs
+++ b/src/Apropos.hs
@@ -74,6 +74,10 @@ module Apropos (
   matches,
   -- Apropos.Pure
   HasPureRunner (..),
+  runPureTest,
+  runPureTestsWhere,
+  enumeratePureTest,
+  enumeratePureTestsWhere,
   -- Usefull Reexports
   Hashable,
   Generic,

--- a/src/Apropos/Pure.hs
+++ b/src/Apropos/Pure.hs
@@ -1,4 +1,10 @@
-module Apropos.Pure (HasPureRunner (..)) where
+module Apropos.Pure (
+  HasPureRunner (..),
+  runPureTest,
+  runPureTestsWhere,
+  enumeratePureTest,
+  enumeratePureTestsWhere,
+) where
 
 import Apropos.Gen.BacktrackingTraversal
 import Apropos.Gen.Enumerate
@@ -15,35 +21,35 @@ class (HasLogicalModel p m, HasParameterisedGenerator p m) => HasPureRunner p m 
   expect :: m :+ p -> Formula p
   script :: m :+ p -> (m -> Bool)
 
-  runPureTest :: m :+ p -> Set p -> Property
-  runPureTest apropos s = property $ do
-    (m :: m) <- traversalContainRetry numRetries $ parameterisedGenerator s
-    satisfiesFormula (expect apropos) s === script apropos m
-    where
-      numRetries :: Int
-      numRetries = rootRetryLimit (Apropos :: m :+ p)
+runPureTest :: forall p m. (HasPureRunner p m) => m :+ p -> Set p -> Property
+runPureTest apropos s = property $ do
+  (m :: m) <- traversalContainRetry numRetries $ parameterisedGenerator s
+  satisfiesFormula (expect apropos) s === script apropos m
+  where
+    numRetries :: Int
+    numRetries = rootRetryLimit (Apropos :: m :+ p)
 
-  runPureTestsWhere :: m :+ p -> String -> Formula p -> Group
-  runPureTestsWhere pm name condition =
-    Group (fromString name) $
-      [ ( fromString $ show $ Set.toList scenario
-        , runPureTest pm scenario
-        )
-      | scenario <- enumerateScenariosWhere condition
-      ]
+runPureTestsWhere :: forall p m. (HasPureRunner p m) => m :+ p -> String -> Formula p -> Group
+runPureTestsWhere pm name condition =
+  Group (fromString name) $
+    [ ( fromString $ show $ Set.toList scenario
+      , runPureTest pm scenario
+      )
+    | scenario <- enumerateScenariosWhere condition
+    ]
 
-  enumeratePureTest :: m :+ p -> Set p -> Property
-  enumeratePureTest apropos s = withTests (1 :: TestLimit) $
-    property $ do
-      let (ms :: [m]) = enumerate $ traversalAsGen $ parameterisedGenerator s
-          run m = satisfiesFormula (expect apropos) s === script apropos m
-      sequence_ (run <$> ms)
+enumeratePureTest :: forall p m. (HasPureRunner p m) => m :+ p -> Set p -> Property
+enumeratePureTest apropos s = withTests (1 :: TestLimit) $
+  property $ do
+    let (ms :: [m]) = enumerate $ traversalAsGen $ parameterisedGenerator s
+        run m = satisfiesFormula (expect apropos) s === script apropos m
+    sequence_ (run <$> ms)
 
-  enumeratePureTestsWhere :: m :+ p -> String -> Formula p -> Group
-  enumeratePureTestsWhere pm name condition =
-    Group (fromString name) $
-      [ ( fromString $ show $ Set.toList scenario
-        , enumeratePureTest pm scenario
-        )
-      | scenario <- enumerateScenariosWhere condition
-      ]
+enumeratePureTestsWhere :: (HasPureRunner p m) => m :+ p -> String -> Formula p -> Group
+enumeratePureTestsWhere pm name condition =
+  Group (fromString name) $
+    [ ( fromString $ show $ Set.toList scenario
+      , enumeratePureTest pm scenario
+      )
+    | scenario <- enumerateScenariosWhere condition
+    ]


### PR DESCRIPTION
Witness that extra methods in `HasPureRunner` are not currently overriden anywhere, as well as a starter template for #33 