### PR TITLE
interleaving of traversals in gen

### DIFF
--- a/apropos.cabal
+++ b/apropos.cabal
@@ -6,6 +6,7 @@ extra-source-files: CHANGELOG.md
 common lang
   default-language:   Haskell2010
   default-extensions:
+    AllowAmbiguousTypes
     BangPatterns
     BinaryLiterals
     ConstraintKinds
@@ -21,6 +22,7 @@ common lang
     EmptyCase
     FlexibleContexts
     FlexibleInstances
+    FunctionalDependencies
     GADTs
     GeneralizedNewtypeDeriving
     HexFloatLiterals
@@ -38,9 +40,7 @@ common lang
     TypeOperators
     TypeSynonymInstances
     UndecidableInstances
-    FunctionalDependencies
-    AllowAmbiguousTypes
-    
+
   build-depends:
     , base              >=4.14
     , containers
@@ -57,6 +57,7 @@ common lang
     , template-haskell
     , text
     , transformers
+
   -- added Hashable v => Hashable (Set v)
 
 

--- a/examples/Spec/Int.hs
+++ b/examples/Spec/Int.hs
@@ -33,7 +33,7 @@ instance HasLogicalModel IntProp Int where
   satisfiesProperty IsSmall i = i <= 10 && i >= -10
 
 instance HasParameterisedGenerator IntProp Int where
-  parameterisedGenerator s = Source $ do
+  parameterisedGenerator s = do
     i <-
       if IsZero `elem` s
         then pure 0

--- a/src/Apropos/Gen.hs
+++ b/src/Apropos/Gen.hs
@@ -1,10 +1,12 @@
+{-# LANGUAGE RankNTypes #-}
 module Apropos.Gen (
   FreeGen (..),
   Gen,
   GenException (..),
   forAll,
   forAllWith,
-  gen,
+  forAllRetryToMaybeScale,
+  errorHandler,
   label,
   failWithFootnote,
   bool,
@@ -14,8 +16,9 @@ module Apropos.Gen (
   element,
   choice,
   genFilter,
-  prune,
   scale,
+  prune,
+  liftPropertyT,
   retry,
   onRetry,
   retryLimit,
@@ -27,7 +30,7 @@ module Apropos.Gen (
 ) where
 
 import Apropos.Gen.Range
-import Control.Monad (guard, replicateM)
+import Control.Monad (replicateM)
 import Control.Monad.Free
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE)
@@ -38,31 +41,73 @@ import Data.String (fromString)
 import Hedgehog (PropertyT)
 import Hedgehog qualified as H
 import Hedgehog.Gen qualified as HGen
-import Hedgehog.Internal.Gen qualified as HIG
-import Hedgehog.Internal.Tree qualified as HIT
 import Hedgehog.Range qualified as HRange
 
-forAll :: Show a => Gen a -> PropertyT IO a
-forAll g = do
-  (ee, labels) <- H.forAll $ runWriterT (runExceptT $ gen g)
-  mapM_ (H.label . fromString) labels
+forAllRetryToMaybeScale :: Show a => Gen a -> Int -> PropertyT IO (Maybe a)
+forAllRetryToMaybeScale g s = do
+  ee <- forAll $ scale (2 * s +) g
+  case ee of
+    Left Retry -> pure Nothing
+    Left (GenException err) -> H.footnote err >> H.failure
+    Right a -> pure $ Just a
+
+forAllWithRetries :: forall a . Show a => Int -> Gen a -> PropertyT IO (Either GenException a)
+forAllWithRetries retries g = go 0
+  where
+    go :: Int -> PropertyT IO (Either GenException a)
+    go l = do
+      res <- forAllRetryToMaybeScale g l
+      case res of
+        Nothing ->
+          if l > retries
+            then pure $ Left Retry
+            else go (l + 1)
+        Just so -> pure $ Right so
+
+
+errorHandler :: Either GenException a -> PropertyT IO a
+errorHandler ee =
   case ee of
     Left Retry -> H.footnote "retry limit reached" >> H.discard
     Left (GenException err) -> H.footnote err >> H.failure
     Right a -> pure a
 
-forAllWith :: forall a. (a -> String) -> Gen a -> PropertyT IO a
-forAllWith s g = do
-  (ee, labels) <- H.forAllWith sh $ runWriterT (runExceptT $ gen g)
+forAll :: Show a => Gen a -> PropertyT IO (Either GenException a)
+forAll = interleaved . gen2Interleaved
+
+forAllWith :: forall a. (a -> String) -> Gen a -> PropertyT IO (Either GenException a)
+forAllWith s = interleavedWith s . gen2Interleaved
+
+forAllWithG :: forall a . (a -> String) -> Generator a -> PropertyT IO (Either GenException a)
+forAllWithG s g = do
+  (ee, labels) <- H.forAllWith sh $ runWriterT (runExceptT g)
   mapM_ (H.label . fromString) labels
-  case ee of
-    Left Retry -> H.footnote "retry limit reached" >> H.discard
-    Left (GenException err) -> H.footnote err >> H.failure
-    Right a -> pure a
+  pure ee
   where
     sh :: (Either GenException a, Set String) -> String
     sh (Left e, _) = show e
     sh (Right a, _) = s a
+
+
+interleaved :: forall a . Show a => Interleaved a -> PropertyT IO (Either GenException a)
+interleaved = interleavedWith show
+
+interleavedWith :: forall a . (a -> String) -> Interleaved a -> PropertyT IO (Either GenException a)
+interleavedWith s m = do
+  res <- forAllWithG sh $ gSteps m
+  case res of
+    Right (Right a) -> pure $ Right a
+    Right (Left c) -> do
+      pres <- pSteps c
+      case pres of
+        Right a -> pure $ Right a
+        Left pc -> interleavedWith s pc
+    Left err -> pure $ Left err
+  where
+    sh :: Either (Interleaved a) a -> String
+    sh (Left _) = "This is unexpected. Generator interleaving failed. Please contact a customer support representative."
+    sh (Right a) = s a
+
 
 data FreeGen next where
   Label :: String -> next -> FreeGen next
@@ -101,8 +146,9 @@ data FreeGen next where
     FreeGen next
   Scale :: forall a next. (Int -> Int) -> Gen a -> (a -> next) -> FreeGen next
   Prune :: forall a next. Gen a -> (a -> next) -> FreeGen next
+  LiftPropertyT :: forall a next. PropertyT IO a -> (a -> next) -> FreeGen next
   ThrowRetry :: forall a next. (a -> next) -> FreeGen next
-  OnRetry :: forall a next. Gen a -> Gen a -> (a -> next) -> FreeGen next
+  OnRetry :: forall a next. Show a => Gen a -> Gen a -> (a -> next) -> FreeGen next
 
 instance Functor FreeGen where
   fmap f (Label l next) = Label l (f next)
@@ -116,6 +162,7 @@ instance Functor FreeGen where
   fmap f (GenFilter c g next) = GenFilter c g (f . next)
   fmap f (Scale s g next) = Scale s g (f . next)
   fmap f (Prune g next) = Prune g (f . next)
+  fmap f (LiftPropertyT p next) = LiftPropertyT p (f . next)
   fmap f (ThrowRetry next) = ThrowRetry (f . next)
   fmap f (OnRetry a b next) = OnRetry a b (f . next)
 
@@ -154,13 +201,16 @@ scale s g = liftF (Scale s g id)
 prune :: Gen a -> Gen a
 prune g = liftF (Prune g id)
 
+liftPropertyT :: PropertyT IO a -> Gen a
+liftPropertyT p = liftF (LiftPropertyT p id)
+
 retry :: Gen a
 retry = liftF (ThrowRetry id)
 
-onRetry :: Gen a -> Gen a -> Gen a
+onRetry :: Show a => Gen a -> Gen a -> Gen a
 onRetry a b = liftF (OnRetry a b id)
 
-retryLimit :: forall a. Int -> Gen a -> Gen a -> Gen a
+retryLimit :: forall a. Show a => Int -> Gen a -> Gen a -> Gen a
 retryLimit lim g done = go lim
   where
     go :: Int -> Gen a
@@ -181,75 +231,117 @@ type GenContext = H.Gen
 
 type Generator = ExceptT GenException (WriterT (Set String) GenContext)
 
-gen :: Gen a -> Generator a
-gen (Free (Label s next)) = lift (tell (Set.singleton s)) >> gen next
-gen (Free (FailWithFootnote s _)) = throwE $ GenException s
-gen (Free (GenBool next)) = lift HGen.bool >>= (gen . next)
-gen (Free (GenInt r next)) = do
-  i <- lift $ HGen.int (hRange r)
-  gen $ next i
-gen (Free (GenList r g next)) = do
+data FreeInterleaved next where
+  G :: forall a next. Generator a -> (a -> next) -> FreeInterleaved next
+  P :: forall a next. PropertyT IO a -> (a -> next) -> FreeInterleaved next
+
+
+instance Functor FreeInterleaved where
+  fmap f (G g next) = G g (fmap f next)
+  fmap f (P p next) = P p (fmap f next)
+
+type Interleaved = Free FreeInterleaved
+
+mapG :: (forall a . Generator a -> Generator a) -> Interleaved b -> Interleaved b
+mapG m (Free (G g next)) = Free (G (m g) (mapG m <$> next))
+mapG m (Free (P p next)) = Free (P p (mapG m <$> next))
+mapG _ (Pure r) = Pure r
+
+gStep :: Interleaved a -> Generator (Either (Maybe (Interleaved a)) a)
+gStep (Pure a) = pure $ Right a
+gStep (Free (G g f)) = Left . Just . f <$> g
+gStep _ = pure $ Left Nothing
+
+gSteps :: Interleaved a -> Generator (Either (Interleaved a) a)
+gSteps m = do
+  mg <- gStep m
+  case mg of
+    Right a -> pure $ Right a
+    Left Nothing -> pure $ Left m
+    Left (Just so) -> gSteps so
+
+gStepsA :: Interleaved a -> Generator (Interleaved a)
+gStepsA m = do
+  mg <- gStep m
+  case mg of
+    Right a -> pure $ Pure a
+    Left Nothing -> pure  m
+    Left (Just so) -> gStepsA so
+
+
+pStep :: Interleaved a -> PropertyT IO (Either (Maybe (Interleaved a)) a)
+pStep (Pure a) = pure $ Right a
+pStep (Free (P g f)) = Left . Just . f <$> g
+pStep _ = pure $ Left Nothing
+
+pSteps :: Interleaved a -> PropertyT IO (Either (Interleaved a) a)
+pSteps m = do
+  mg <- pStep m
+  case mg of
+    Right a -> pure $ Right a
+    Left Nothing -> pure $ Left m
+    Left (Just so) -> pSteps so
+
+liftG :: Generator a -> Interleaved a
+liftG g = liftF (G g id)
+
+liftP :: PropertyT IO a -> Interleaved a
+liftP p = liftF (P p id)
+
+gen2Interleaved :: Gen a -> Interleaved a
+gen2Interleaved (Free (LiftPropertyT p next)) = liftP p >>= (gen2Interleaved . next)
+gen2Interleaved (Free (Label s next)) = liftG (lift (tell (Set.singleton s))) >> gen2Interleaved next
+gen2Interleaved (Free (FailWithFootnote s _)) = liftG $ throwE $ GenException s
+gen2Interleaved (Free (GenBool next)) = liftG (lift HGen.bool) >>= (gen2Interleaved . next)
+gen2Interleaved (Free (GenInt r next)) = do
+  i <- liftG $ lift $ HGen.int (hRange r)
+  gen2Interleaved $ next i
+gen2Interleaved (Free (GenList r g next)) = do
   let gs = int r >>= \l -> replicateM l g
   gs >>>= next
-gen (Free (GenShuffle ls next)) = do
-  s <- lift $ HGen.shuffle ls
-  gen $ next s
-gen (Free (GenElement ls next)) = do
+gen2Interleaved (Free (GenShuffle ls next)) = do
+  s <- liftG $ lift $ HGen.shuffle ls
+  gen2Interleaved $ next s
+gen2Interleaved (Free (GenElement ls next)) = do
   if null ls
-    then throwE $ GenException "GenElement empty list"
+    then liftG $ throwE $ GenException "GenElement empty list"
     else do
-      s <- lift $ HGen.element ls
-      gen $ next s
-gen (Free (GenChoice gs next)) = do
+      s <- liftG $ lift $ HGen.element ls
+      gen2Interleaved $ next s
+gen2Interleaved (Free (GenChoice gs next)) = do
   let l = length gs
   if l == 0
-    then throwE $ GenException "GenChoice: list length zero"
+    then liftG $ throwE $ GenException "GenChoice: list length zero"
     else do
-      i <- lift (HGen.int (HRange.linear 0 (l - 1)))
+      i <- liftG $ lift (HGen.int (HRange.linear 0 (l - 1)))
       (gs !! i) >>>= next
-gen (Free (GenFilter c g next)) = do
-  res <- filter' c $ gen g
-  gen $ next res
-gen (Free (Scale s g next)) =
-  HGen.scale (\(HRange.Size x) -> HRange.Size (s x)) (gen g) >>= gen . next
-gen (Free (Prune g next)) = HGen.prune (gen g) >>= gen . next
-gen (Free (ThrowRetry _)) = throwE Retry
-gen (Free (OnRetry a b next)) = do
-  res <- lift $ runExceptT (gen a)
+gen2Interleaved (Free (GenFilter c g next)) = do
+  let f = do
+           res <- g
+           if c res
+              then pure res
+              else retry
+  res <- liftP $ forAllWithRetries 100 f
   case res of
-    Right r -> gen $ next r
-    Left Retry -> gen b >>= (gen . next)
-    Left err -> throwE err
-gen (Pure a) = pure a
+    Left err -> liftG (throwE err)
+    Right a -> gen2Interleaved $ next a
+gen2Interleaved (Free (Scale s g next)) = do
+  sr <- mapG (HGen.scale (\(HRange.Size x) -> HRange.Size (s x))) (liftG (gStepsA (gen2Interleaved g)))
+  sr >>= gen2Interleaved . next
+gen2Interleaved (Free (Prune g next)) = do
+  gr <- mapG HGen.prune $ liftG (gStepsA (gen2Interleaved g))
+  gr >>= gen2Interleaved . next
+gen2Interleaved (Free (ThrowRetry _)) = liftG $ throwE Retry
+gen2Interleaved (Free (OnRetry a b next)) = do
+  res <- liftP $ forAll a
+  case res of
+    Right r -> gen2Interleaved $ next r
+    Left Retry -> gen2Interleaved b >>= (gen2Interleaved . next)
+    Left err -> liftG $ throwE err
+gen2Interleaved (Pure a) = pure a
 
-(>>>=) :: Gen r -> (r -> Gen a) -> Generator a
-(>>>=) a b = gen a >>= gen . b
-
-fromPred :: (a -> Bool) -> a -> Maybe a
-fromPred p a = a <$ guard (p a)
-
-filter' :: (a -> Bool) -> Generator a -> Generator a
-filter' p =
-  mapMaybe (fromPred p)
-
-mapMaybe :: forall a b. (a -> Maybe b) -> Generator a -> Generator b
-mapMaybe p gen0 =
-  let try k =
-        if k > 100
-          then throwE Retry
-          else do
-            (x, g) <- lift $ lift $ HGen.freeze $ HGen.scale (2 * k +) (runWriterT (runExceptT gen0))
-            case (p <$>) $ fst x of
-              Right (Just _) -> do
-                let withGenT f = H.fromGenT . f . H.toGenT
-                let toMaybe' z = case fst z of
-                      Right a -> a
-                      Left _ -> error "This should be impossible."
-                lift $ tell $ snd x
-                lift $ lift $ withGenT (HIG.mapGenT (HIT.mapMaybeMaybeT p)) (toMaybe' <$> g)
-              Left (GenException e) -> throwE $ GenException e
-              _ -> try (k + 1)
-   in try 0
+(>>>=) :: Gen r -> (r -> Gen a) -> Interleaved a
+(>>>=) a b = gen2Interleaved a >>= gen2Interleaved . b
 
 hRange :: Range -> H.Range Int
 hRange (Singleton s) = HRange.singleton s

--- a/src/Apropos/Gen/BacktrackingTraversal.hs
+++ b/src/Apropos/Gen/BacktrackingTraversal.hs
@@ -7,7 +7,7 @@ module Apropos.Gen.BacktrackingTraversal (
 import Apropos.Gen
 import Apropos.HasPermutationGenerator.Morphism
 import Control.Monad ((>=>))
-import Control.Monad.Trans.Maybe (MaybeT(..),runMaybeT)
+import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Hedgehog (PropertyT)
 import Hedgehog qualified as H
 
@@ -86,15 +86,16 @@ backtrackingRetryTraverse retries s (t : ts) =
 
 backtrackingBind :: Monad m => Int -> Int -> (Int -> m (Maybe a)) -> (a -> m (Maybe a)) -> m (Maybe a)
 backtrackingBind retries counter f g = do
-      runMaybeT
-        ( do
-          res <- MaybeT $ f counter
-          MaybeT $ g res
-        ) >>= \case
-                 Just so -> pure $ Just so
-                 Nothing
-                   | counter > retries -> pure Nothing
-                   | otherwise -> backtrackingBind retries (counter + 1) f g
+  runMaybeT
+    ( do
+        res <- MaybeT $ f counter
+        MaybeT $ g res
+    )
+    >>= \case
+      Just so -> pure $ Just so
+      Nothing
+        | counter > retries -> pure Nothing
+        | otherwise -> backtrackingBind retries (counter + 1) f g
 
 forAllRetryToMaybeScale :: Show a => Gen a -> Int -> PropertyT IO (Maybe a)
 forAllRetryToMaybeScale g s = do
@@ -103,4 +104,3 @@ forAllRetryToMaybeScale g s = do
     Left Retry -> pure Nothing
     Left (GenException err) -> H.footnote err >> H.failure
     Right a -> pure $ Just a
-

--- a/src/Apropos/Gen/BacktrackingTraversal.hs
+++ b/src/Apropos/Gen/BacktrackingTraversal.hs
@@ -16,7 +16,7 @@ data Traversal p m where
   Source :: Gen m -> Traversal p m
   Traversal :: Traversal p m -> (m -> Gen [Morphism p m]) -> Traversal p m
 
-traversalInGen :: Show m => Traversal p m  -> Gen m
+traversalInGen :: Show m => Traversal p m -> Gen m
 traversalInGen = liftPropertyT . traversalContainRetry 100
 
 traversalAsGen :: Traversal p m -> Gen m

--- a/src/Apropos/Gen/BacktrackingTraversal.hs
+++ b/src/Apropos/Gen/BacktrackingTraversal.hs
@@ -1,6 +1,7 @@
 module Apropos.Gen.BacktrackingTraversal (
   Traversal (..),
   traversalAsGen,
+  traversalInGen,
   traversalContainRetry,
 ) where
 
@@ -14,6 +15,9 @@ import Hedgehog qualified as H
 data Traversal p m where
   Source :: Gen m -> Traversal p m
   Traversal :: Traversal p m -> (m -> Gen [Morphism p m]) -> Traversal p m
+
+traversalInGen :: Show m => Traversal p m  -> Gen m
+traversalInGen = liftPropertyT . traversalContainRetry 100
 
 traversalAsGen :: Traversal p m -> Gen m
 traversalAsGen (Source g) = g

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -65,8 +65,8 @@ sampleGenTest ::
   m :+ p ->
   Property
 sampleGenTest _ = property $ do
-  (ps :: Set p) <- forAll (genPropSet @p)
-  (m :: m) <- forAll $ traversalAsGen $ parameterisedGenerator ps
+  (ps :: Set p) <- errorHandler =<< forAll (genPropSet @p)
+  (m :: m) <- errorHandler =<< forAll (traversalAsGen $ parameterisedGenerator ps)
   properties m === ps
 
 enumerateGeneratorTest ::
@@ -97,7 +97,5 @@ genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen m
 genSatisfying f = do
   label $ fromString $ show f
   s <- element (enumerateScenariosWhere f)
-  traversalAsGen $ parameterisedGenerator s -- TODO this doesn't do shrink containment...
-  -- we can lift a Traversal into Gen
-  -- like GenWrap but for Traversal
-  -- or something...
+  liftPropertyT $ traversalContainRetry 100 $ parameterisedGenerator s
+

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -98,4 +98,3 @@ genSatisfying f = do
   label $ fromString $ show f
   s <- element (enumerateScenariosWhere f)
   liftPropertyT $ traversalContainRetry 100 $ parameterisedGenerator s
-

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -62,7 +62,7 @@ sampleGenTest ::
   Property
 sampleGenTest _ = property $ test >>= errorHandler
   where
-    test = forAll $  do
+    test = forAll $ do
       (ps :: Set p) <- genPropSet @p
       (m :: m) <- parameterisedGenerator ps
       properties m === ps
@@ -73,13 +73,14 @@ enumerateGeneratorTest ::
   m :+ p ->
   Set p ->
   Property
-enumerateGeneratorTest _ s = withTests (1 :: TestLimit) $
-  property $ test >>= errorHandler
+enumerateGeneratorTest _ s =
+  withTests (1 :: TestLimit) $
+    property $ test >>= errorHandler
   where
     test = forAll $ do
-        let (ms :: [m]) = enumerate $ parameterisedGenerator s
-            run m = properties m === s
-        sequence_ (run <$> ms)
+      let (ms :: [m]) = enumerate $ parameterisedGenerator s
+          run m = properties m === s
+      sequence_ (run <$> ms)
 
 enumerateGeneratorTestsWhere ::
   HasParameterisedGenerator p m =>
@@ -98,4 +99,3 @@ genSatisfying f = do
   label $ fromString $ show f
   s <- element (enumerateScenariosWhere f)
   parameterisedGenerator s
-

--- a/src/Apropos/HasParameterisedGenerator.hs
+++ b/src/Apropos/HasParameterisedGenerator.hs
@@ -8,8 +8,7 @@ module Apropos.HasParameterisedGenerator (
   sampleGenTest,
 ) where
 
-import Apropos.Gen hiding ((===))
-import Apropos.Gen.BacktrackingTraversal
+import Apropos.Gen
 import Apropos.Gen.Enumerate
 import Apropos.HasLogicalModel
 import Apropos.LogicalModel
@@ -18,12 +17,10 @@ import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (fromString)
-import Hedgehog (Group (..), Property, TestLimit, property, withTests, (===))
+import Hedgehog (Group (..), Property, TestLimit, property, withTests)
 
 class (HasLogicalModel p m, Show m) => HasParameterisedGenerator p m where
-  parameterisedGenerator :: Set p -> Traversal p m
-  rootRetryLimit :: m :+ p -> Int
-  rootRetryLimit _ = 100
+  parameterisedGenerator :: Set p -> Gen m
 
 -- TODO caching calls to the solver in genSatisfying would probably be worth it
 runGeneratorTest ::
@@ -32,12 +29,11 @@ runGeneratorTest ::
   m :+ p ->
   Set p ->
   Property
-runGeneratorTest _ s = property $ do
-  (m :: m) <- traversalContainRetry numRetries $ parameterisedGenerator s
-  properties m === s
+runGeneratorTest _ s = property $ test >>= errorHandler
   where
-    numRetries :: Int
-    numRetries = rootRetryLimit (Apropos :: Apropos (m, p))
+    test = forAll $ do
+      (m :: m) <- parameterisedGenerator s
+      properties m === s
 
 runGeneratorTestsWhere ::
   HasParameterisedGenerator p m =>
@@ -64,10 +60,12 @@ sampleGenTest ::
   HasParameterisedGenerator p m =>
   m :+ p ->
   Property
-sampleGenTest _ = property $ do
-  (ps :: Set p) <- errorHandler =<< forAll (genPropSet @p)
-  (m :: m) <- errorHandler =<< forAll (traversalAsGen $ parameterisedGenerator ps)
-  properties m === ps
+sampleGenTest _ = property $ test >>= errorHandler
+  where
+    test = forAll $  do
+      (ps :: Set p) <- genPropSet @p
+      (m :: m) <- parameterisedGenerator ps
+      properties m === ps
 
 enumerateGeneratorTest ::
   forall p m.
@@ -76,10 +74,12 @@ enumerateGeneratorTest ::
   Set p ->
   Property
 enumerateGeneratorTest _ s = withTests (1 :: TestLimit) $
-  property $ do
-    let (ms :: [m]) = enumerate $ traversalAsGen $ parameterisedGenerator s
-        run m = properties m === s
-    sequence_ (run <$> ms)
+  property $ test >>= errorHandler
+  where
+    test = forAll $ do
+        let (ms :: [m]) = enumerate $ parameterisedGenerator s
+            run m = properties m === s
+        sequence_ (run <$> ms)
 
 enumerateGeneratorTestsWhere ::
   HasParameterisedGenerator p m =>
@@ -97,4 +97,5 @@ genSatisfying :: HasParameterisedGenerator p m => Formula p -> Gen m
 genSatisfying f = do
   label $ fromString $ show f
   s <- element (enumerateScenariosWhere f)
-  liftPropertyT $ traversalContainRetry 100 $ parameterisedGenerator s
+  parameterisedGenerator s
+

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -59,7 +59,7 @@ class (Hashable p, HasLogicalModel p m, Show m) => HasPermutationGenerator p m w
                 "No permutation edges defined."
                 [
                   ( fromString "no edges defined"
-                  , property $ void $ forAll (failWithFootnote "no Morphisms defined" :: Gen String)
+                  , property $ void $ errorHandler =<< forAll (failWithFootnote "no Morphisms defined" :: Gen String)
                   )
                 ]
             ]
@@ -112,7 +112,8 @@ class (Hashable p, HasLogicalModel p m, Show m) => HasPermutationGenerator p m w
           isRequired =
             let inEdges = [length v | (_, v) <- Map.toList pem, pe `elem` v]
              in elem 1 inEdges
-          runRequiredTest = property $
+          runRequiredTest = property (errorHandler =<< requiredTestGen)
+          requiredTestGen =
             forAll $ do
               if isRequired || allowRedundentMorphisms (Apropos :: p :+ m)
                 then pure ()

--- a/src/Apropos/HasPermutationGenerator.hs
+++ b/src/Apropos/HasPermutationGenerator.hs
@@ -123,8 +123,9 @@ class (Hashable p, HasLogicalModel p m, Show m) => HasPermutationGenerator p m w
                       fromString ("Morphism " <> name pe <> " is not required to make graph strongly connected.")
                         $+$ hang "Edge:" 4 (ppDoc $ name pe)
           runEdgeTest f = forAll $ do
-            liftPropertyT $ traversalContainRetry (traversalRetryLimit (Apropos :: m :+ p)) $
-              Traversal (mTra f) (const $ pure [wrapMorphismWithContractCheck pe])
+            liftPropertyT $
+              traversalContainRetry (traversalRetryLimit (Apropos :: m :+ p)) $
+                Traversal (mTra f) (const $ pure [wrapMorphismWithContractCheck pe])
 
   buildTraversal :: Gen m -> Set p -> Traversal p m
   buildTraversal s tp = do
@@ -149,10 +150,11 @@ class (Hashable p, HasLogicalModel p m, Show m) => HasPermutationGenerator p m w
           transformModel cache pedges m targetProperties
      in Traversal (Source s) (go tp)
 
-
   buildGen :: Gen m -> Set p -> Gen m
-  buildGen s p = liftPropertyT $ traversalContainRetry (traversalRetryLimit (Apropos :: m :+ p))
-                           $ buildTraversal s p
+  buildGen s p =
+    liftPropertyT $
+      traversalContainRetry (traversalRetryLimit (Apropos :: m :+ p)) $
+        buildTraversal s p
 
   findNoPath ::
     m :+ p ->


### PR DESCRIPTION
Allow traversals to be embedded in `Gen` computations. This solves the issue of allowing`genSatisfying` to leverage the backtracking retry behavior of traversals.