### PR TITLE
Updated examples to better motivate `apropos`

### DIFF
--- a/apropos.cabal
+++ b/apropos.cabal
@@ -99,4 +99,5 @@ test-suite examples
     , mtl
     , tasty
     , tasty-hedgehog
+    , tasty-hunit
     , text

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -4,8 +4,8 @@ import Spec.IntCompact
 import Spec.IntSimple
 
 import Test.Tasty
-import Test.Tasty.Hedgehog (fromGroup, testProperty)
 import Test.Tasty.HUnit (testCase)
+import Test.Tasty.Hedgehog (fromGroup, testProperty)
 
 main :: IO ()
 main = defaultMain tests
@@ -16,15 +16,15 @@ tests =
     "all tests"
     [ testGroup
         "Simple Int types with logic"
-        [ testProperty "Bad property test: this should fail!" intSimpleBadProperty 
-        , testCase "This is why:" intSimpleExampleUnit 
-        , fromGroup intSimpleSelfTest 
-        , fromGroup intSimpleAproposExample 
+        [ testProperty "Bad property test: this should fail!" intSimpleBadProperty
+        , testCase "This is why:" intSimpleExampleUnit
+        , fromGroup intSimpleSelfTest
+        , fromGroup intSimpleAproposExample
         ]
     , testGroup
         "Compact Int types"
         [ fromGroup intCompactSelfTest
         , testCase "Failing example" intCompactExampleUnit
-        , fromGroup intCompactAproposExample  
+        , fromGroup intCompactAproposExample
         ]
     ]

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -4,7 +4,8 @@ import Spec.IntCompact
 import Spec.IntSimple
 
 import Test.Tasty
-import Test.Tasty.Hedgehog (fromGroup)
+import Test.Tasty.Hedgehog (fromGroup, testProperty)
+import Test.Tasty.HUnit (testCase)
 
 main :: IO ()
 main = defaultMain tests
@@ -14,16 +15,16 @@ tests =
   testGroup
     "all tests"
     [ testGroup
-        "Description"
-        [ testGroup
-            "Simple Int types with logic"
-            [ fromGroup intSimpleGenTests
-            , fromGroup intSimplePureTests
-            ]
-        , testGroup
-            "Compact Int types"
-            [ fromGroup intCompactGenTests
-            , fromGroup intCompactPureTests
-            ]
+        "Simple Int types with logic"
+        [ testProperty "Bad property test: this should fail!" intSimpleBadProperty 
+        , testCase "This is why:" intSimpleExampleUnit 
+        , fromGroup intSimpleSelfTest 
+        , fromGroup intSimpleAproposExample 
+        ]
+    , testGroup
+        "Compact Int types"
+        [ fromGroup intCompactSelfTest
+        , testCase "Failing example" intCompactExampleUnit
+        , fromGroup intCompactAproposExample  
         ]
     ]

--- a/examples/Spec/IntCompact.hs
+++ b/examples/Spec/IntCompact.hs
@@ -1,7 +1,7 @@
 module Spec.IntCompact (
   intCompactSelfTest,
   intCompactExampleUnit,
-  intCompactAproposExample
+  intCompactAproposExample,
 ) where
 
 import Apropos
@@ -63,16 +63,17 @@ intCompactSelfTest =
     "self test"
     (selfTest @IntDescr)
 
--- Not only does 'apropos' test for values that have the given properties, it also 
+-- Not only does 'apropos' test for values that have the given properties, it also
 -- ensures that those without them fail the test.
 intCompactAproposExample :: Group
 intCompactAproposExample =
   Group
-    "apropos testing" $
-    runTests @IntDescr AproposTest
-      { expect =
-        \case
-          Positive _ -> True  -- all positive values should pass.
-          _ -> False          -- all other values should fail!
-      , aproposTest = assert . hasNegativeNegation
-      }
+    "apropos testing"
+    $ runTests @IntDescr
+      AproposTest
+        { expect =
+            \case
+              Positive _ -> True -- all positive values should pass.
+              _ -> False -- all other values should fail!
+        , aproposTest = assert . hasNegativeNegation
+        }

--- a/examples/Spec/IntCompact.hs
+++ b/examples/Spec/IntCompact.hs
@@ -1,13 +1,18 @@
 module Spec.IntCompact (
-  intCompactGenTests,
-  intCompactPureTests,
+  intCompactSelfTest,
+  intCompactExampleUnit,
+  intCompactAproposExample
 ) where
 
 import Apropos
 import Hedgehog (Group (Group), assert)
 import Hedgehog.Gen (int)
 import Hedgehog.Range (linear)
+import Test.Tasty.HUnit (Assertion, assertBool)
 
+-- This is a variant of 'IntSimple', demonstrating a different way of building description types. Also, for variety, we switched the test up to show conditional testing.
+
+-- We've worked a bit harder defining the description, and can capture all the logic in the type. It's now impossible to construct a Large Zero or Small isBound.
 data IntDescr
   = Zero
   | Positive Size
@@ -20,6 +25,8 @@ data Size = Small | Large {isBound :: Bool}
   deriving anyclass (SOPGeneric, HasDatatypeInfo)
 
 instance Description IntDescr Int where
+  -- 'describe' is arguably simpler.
+  describe :: Int -> IntDescr
   describe 0 = Zero
   describe i
     | i > 0 = Positive size
@@ -30,6 +37,9 @@ instance Description IntDescr Int where
         | i < 11 && i > -111 = Small
         | otherwise = Large {isBound = i == minBound || i == maxBound}
 
+  -- no need for 'refineDescription' here!
+
+  -- Also maybe a bit more straightforward.
   genDescribed = \case
     Zero -> pure 0
     Positive (Large True) -> pure maxBound
@@ -39,20 +49,30 @@ instance Description IntDescr Int where
     Negative (Large False) -> int (linear (minBound + 1) (-11))
     Negative Small -> int (linear (-10) (-1))
 
-intCompactGenTests :: Group
-intCompactGenTests =
+-- This should hold for all positive integers, but no negative integers or zero.
+hasNegativeNegation :: Int -> Bool
+hasNegativeNegation n = negate n < 0
+
+-- it doesn't, unfortunately.
+intCompactExampleUnit :: Assertion
+intCompactExampleUnit = assertBool "negate minBound >= 0" (not $ hasNegativeNegation minBound)
+
+intCompactSelfTest :: Group
+intCompactSelfTest =
   Group
     "self test"
     (selfTest @IntDescr)
 
-intCompactPureTests :: Group
-intCompactPureTests =
+-- Not only does 'apropos' test for values that have the given properties, it also 
+-- ensures that those without them fail the test.
+intCompactAproposExample :: Group
+intCompactAproposExample =
   Group
-    "AcceptsSmallNegativeInts"
-    . runTests @IntDescr
-    $ AproposTest
-      { expect = \case
-          Negative Small -> True
-          _ -> False
-      , aproposTest = \i -> assert $ i < 0 && i >= -10
+    "apropos testing" $
+    runTests @IntDescr AproposTest
+      { expect =
+        \case
+          Positive _ -> True  -- all positive values should pass.
+          _ -> False          -- all other values should fail!
+      , aproposTest = assert . hasNegativeNegation
       }

--- a/examples/Spec/IntSimple.hs
+++ b/examples/Spec/IntSimple.hs
@@ -6,10 +6,10 @@ module Spec.IntSimple (
 ) where
 
 import Apropos
-import Hedgehog (MonadGen, assert, property, forAll, Property, Group (Group))
+import Hedgehog (Group (Group), MonadGen, Property, assert, forAll, property)
 import Hedgehog.Gen (int)
 import Hedgehog.Range (linear)
-import Test.Tasty.HUnit (assertBool, Assertion)
+import Test.Tasty.HUnit (Assertion, assertBool)
 
 -- This example is based on https://github.com/nick8325/quickcheck/issues/98, and is due to our very own Baldur Blöndal.
 
@@ -103,8 +103,9 @@ intSimpleSelfTest =
 intSimpleAproposExample :: Group
 intSimpleAproposExample =
   Group
-    "apropos testing" $
-    runTests @IntDescr AproposTest
-      { expect = const True -- should hold for all negative integers
-      , aproposTest = assert . absIsAlwaysPositive
-      }
+    "apropos testing"
+    $ runTests @IntDescr
+      AproposTest
+        { expect = const True -- should hold for all negative integers
+        , aproposTest = assert . absIsAlwaysPositive
+        }

--- a/examples/Spec/IntSimple.hs
+++ b/examples/Spec/IntSimple.hs
@@ -1,21 +1,39 @@
 module Spec.IntSimple (
-  intSimpleGenTests,
-  intSimplePureTests,
-  IntDescr,
+  intSimpleSelfTest,
+  intSimpleBadProperty,
+  intSimpleExampleUnit,
+  intSimpleAproposExample,
 ) where
 
 import Apropos
-import Hedgehog (Group (Group), MonadGen, assert)
+import Hedgehog (MonadGen, assert, property, forAll, Property, Group (Group))
 import Hedgehog.Gen (int)
 import Hedgehog.Range (linear)
+import Test.Tasty.HUnit (assertBool, Assertion)
 
+-- This example is based on https://github.com/nick8325/quickcheck/issues/98, and is due to our very own Baldur Blöndal.
+
+-- This should always return true. But it has a bug!
+absIsAlwaysPositive :: Int -> Bool
+absIsAlwaysPositive n = abs n >= 0
+
+-- abs minBound == minBound :-(
+intSimpleExampleUnit :: Assertion
+intSimpleExampleUnit = assertBool "abs minBound >= 0" (absIsAlwaysPositive minBound)
+
+-- A naive property test is unlikely to catch this.
+intSimpleBadProperty :: Property
+intSimpleBadProperty =
+  property $ forAll (int (linear 0 minBound)) >>= assert . absIsAlwaysPositive
+
+-- Let's define a type that captures the interesting properties of 'Int's.
 data IntDescr = IntDescr
   { sign :: Sign
   , size :: Size
-  , isBound :: Bool
+  , isBound :: Bool -- Is this 'minBound' or 'maxBound'?
   }
   deriving stock (Generic, Eq, Ord, Show)
-  deriving anyclass (SOPGeneric, HasDatatypeInfo)
+  deriving anyclass (SOPGeneric, HasDatatypeInfo) -- These are required, unfortunately.
 
 data Sign = Positive | Negative | Zero
   deriving stock (Generic, Eq, Ord, Show)
@@ -26,6 +44,8 @@ data Size = Large | Small
   deriving anyclass (SOPGeneric, HasDatatypeInfo)
 
 instance Description IntDescr Int where
+  -- Describe an 'Int'
+  describe :: Int -> IntDescr
   describe i =
     IntDescr
       { sign =
@@ -40,12 +60,16 @@ instance Description IntDescr Int where
       , isBound = i == minBound || i == maxBound
       }
 
+  -- Not all 'IntDescr's are valid. Let's define which ones are.
+  refineDescription :: Formula (Attribute IntDescr)
   refineDescription =
     All
       [ attr [("IntDescr", "sign")] "Zero" :->: attr [("IntDescr", "size")] "Small"
       , attr [("IntDescr", "isBound")] "True" :->: attr [("IntDescr", "size")] "Large"
       ]
 
+  -- We define how to generate values matching a given description.
+  genDescribed :: (MonadGen m) => IntDescr -> m Int
   genDescribed s =
     case sign s of
       Zero -> pure 0
@@ -68,18 +92,19 @@ instance Description IntDescr Int where
             Small -> int (linear (sig 1) (sig 10))
             Large -> int (linear (sig 11) (bound + sig (-1)))
 
-intSimpleGenTests :: Group
-intSimpleGenTests =
+-- Let's first test that our instance is lawful.
+intSimpleSelfTest :: Group
+intSimpleSelfTest =
   Group
     "self test"
     (selfTest @IntDescr)
 
-intSimplePureTests :: Group
-intSimplePureTests =
+-- And we catch our bug!
+intSimpleAproposExample :: Group
+intSimpleAproposExample =
   Group
-    "AcceptsSmallNegativeInts"
-    . runTests @IntDescr
-    $ AproposTest
-      { expect = \d -> size d == Small && sign d == Negative
-      , aproposTest = \i -> assert $ i < 0 && i >= -10
+    "apropos testing" $
+    runTests @IntDescr AproposTest
+      { expect = const True -- should hold for all negative integers
+      , aproposTest = assert . absIsAlwaysPositive
       }

--- a/src/Apropos/Generator.hs
+++ b/src/Apropos/Generator.hs
@@ -6,11 +6,11 @@ module Apropos.Generator (
   selfTestWhere,
 ) where
 
-import Apropos.Description (DeepHasDatatypeInfo, Description (..), variablesToDescription, scenarios)
+import Apropos.Description (DeepHasDatatypeInfo, Description (..), scenarios, variablesToDescription)
+import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.String (IsString, fromString)
 import Hedgehog (Property, PropertyT, forAll, property, (===))
-import Data.Set (Set)
 
 runTest :: (Show a, Description d a) => (a -> PropertyT IO ()) -> d -> Property
 runTest cond d = property $ forAll (genDescribed d) >>= cond
@@ -34,4 +34,3 @@ selfTestWhere ::
   (d -> Bool) ->
   [(s, Property)]
 selfTestWhere = decorateTests selfTestForDescription . filteredTests
-

--- a/src/Apropos/Generator.hs
+++ b/src/Apropos/Generator.hs
@@ -1,31 +1,37 @@
 module Apropos.Generator (
   runTest,
+  filteredTests,
+  decorateTests,
   selfTest,
   selfTestWhere,
 ) where
 
-import Apropos.Description (DeepHasDatatypeInfo, Description (..), Attribute, enumerateScenariosWhere, variablesToDescription)
-import Apropos.Formula (Formula (..))
+import Apropos.Description (DeepHasDatatypeInfo, Description (..), variablesToDescription, scenarios)
 import Data.Set qualified as Set
 import Data.String (IsString, fromString)
 import Hedgehog (Property, PropertyT, forAll, property, (===))
+import Data.Set (Set)
 
 runTest :: (Show a, Description d a) => (a -> PropertyT IO ()) -> d -> Property
 runTest cond d = property $ forAll (genDescribed d) >>= cond
+
+filteredTests :: forall d a. (Description d a, DeepHasDatatypeInfo d, Ord d) => (d -> Bool) -> Set d
+filteredTests f = Set.filter f . Set.map variablesToDescription $ scenarios @d
+
+decorateTests :: (IsString s, Show d) => (d -> Property) -> Set d -> [(s, Property)]
+decorateTests f = map (\d -> (fromString $ show d, f d)) . Set.toList
 
 -- TODO caching calls to the solver in genSatisfying would probably be worth it
 selfTestForDescription :: forall d a. (Eq d, Show d, Show a, Description d a) => d -> Property
 selfTestForDescription d = runTest (\a -> describe a === d) d
 
 selfTest :: forall d a s. (Ord d, Show d, Show a, Description d a, DeepHasDatatypeInfo d, IsString s) => [(s, Property)]
-selfTest = selfTestWhere @d Yes
+selfTest = selfTestWhere @d (const True)
 
 selfTestWhere ::
   forall d a s.
   (Ord d, Show d, Show a, Description d a, DeepHasDatatypeInfo d, IsString s) =>
-  Formula (Attribute d) ->
+  (d -> Bool) ->
   [(s, Property)]
-selfTestWhere condition =
-  [ (fromString $ show $ variablesToDescription scenario, selfTestForDescription (variablesToDescription scenario))
-  | scenario <- Set.toList $ enumerateScenariosWhere condition
-  ]
+selfTestWhere = decorateTests selfTestForDescription . filteredTests
+

--- a/src/Apropos/Runner.hs
+++ b/src/Apropos/Runner.hs
@@ -4,12 +4,11 @@ module Apropos.Runner (
   runTestsWhere,
 ) where
 
-import Apropos.Description (DeepHasDatatypeInfo, Description (..), scenarios, variablesToDescription)
-import Apropos.Generator (runTest)
+import Apropos.Description (DeepHasDatatypeInfo, Description (..))
+import Apropos.Generator (runTest, filteredTests, decorateTests)
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 import Data.Either (isRight)
-import Data.Set qualified as Set
-import Data.String (IsString, fromString)
+import Data.String (IsString)
 import Hedgehog (Property, PropertyT, (===))
 import Hedgehog.Internal.Property (PropertyT (PropertyT), TestT (TestT, unTest), unPropertyT)
 
@@ -23,7 +22,7 @@ runAproposTest atest d =
   runTest
     ( \a -> do
         b <- passes (aproposTest atest a)
-        b === expect atest d
+        expect atest d === b
     )
     d
   where
@@ -41,9 +40,4 @@ runTests :: forall d a s. (Show d, Show a, Ord d, Description d a, DeepHasDataty
 runTests = runTestsWhere (const True)
 
 runTestsWhere :: forall d a s. (Show d, Show a, Ord d, Description d a, DeepHasDatatypeInfo d, IsString s) => (d -> Bool) -> AproposTest d a -> [(s, Property)]
-runTestsWhere cond atest =
-  [ ( fromString $ show scenario
-    , runAproposTest atest scenario
-    )
-  | scenario <- Set.toList . Set.filter cond . Set.map variablesToDescription $ scenarios
-  ]
+runTestsWhere cond atest = decorateTests (runAproposTest atest) $ filteredTests cond

--- a/src/Apropos/Runner.hs
+++ b/src/Apropos/Runner.hs
@@ -5,7 +5,7 @@ module Apropos.Runner (
 ) where
 
 import Apropos.Description (DeepHasDatatypeInfo, Description (..))
-import Apropos.Generator (runTest, filteredTests, decorateTests)
+import Apropos.Generator (decorateTests, filteredTests, runTest)
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 import Data.Either (isRight)
 import Data.String (IsString)


### PR DESCRIPTION
Might help toward #29? 😉

Some of these tests fail, for demonstration purposes. This might be a headache if and when we get CI on `apropos-lite`.